### PR TITLE
Mistyped Code corrected

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -137,7 +137,7 @@ int main(){
         logic();
 
         #ifdef __WIN32
-        sleep(9);
+        Sleep(100);
         #endif
         #ifdef __linux
         usleep(100000);


### PR DESCRIPTION
Instead of Sleep(), by mistake sleep() had been written in the code at line:140 , which has been corrected with this commit. I am greatly sorry for my typing error, I had only verified the program on linux. #1 